### PR TITLE
Normalize matrix weights to a mWeights in CMTF

### DIFF
--- a/tensorpack/cmtf.py
+++ b/tensorpack/cmtf.py
@@ -16,7 +16,7 @@ tl.set_backend('numpy')
 
 def buildMat(tFac):
     """ Build the matrix in CMTF from the factors. """
-    return tFac.factors[0] @ tFac.mFactor.T
+    return tFac.factors[0] @ (tFac.mFactor * tFac.mWeights).T
 
 
 def calcR2X(tFac, tIn=None, mIn=None):
@@ -142,7 +142,9 @@ def cp_normalize(tFac):
         scales = np.linalg.norm(factor, ord=np.inf, axis=0)
         tFac.weights *= scales
         if i == 0 and hasattr(tFac, 'mFactor'):
-            tFac.mFactor *= scales
+            mScales = np.linalg.norm(tFac.mFactor, ord=np.inf, axis=0)
+            tFac.mWeights = scales * mScales
+            tFac.mFactor /= mScales
 
         tFac.factors[i] /= scales
 

--- a/tensorpack/test/test_cmtf.py
+++ b/tensorpack/test/test_cmtf.py
@@ -20,7 +20,7 @@ def test_cmtf_R2X():
     """ Test to ensure R2X for higher components is larger. """
     arr = []
     tensor = createCube(missing=0.2, size=(10, 20, 25))
-    matrix = createCube(missing=0.2, size=(10, 15))
+    matrix = createCube(missing=0.05, size=(10, 15))
     for i in range(1, 5):
         facT = perform_CMTF(tensor, matrix, r=i)
         assert np.all(np.isfinite(facT.factors[0]))
@@ -58,7 +58,7 @@ def test_cp():
 def test_delete():
     """ Test deleting a component results in a valid tensor. """
     tOrig = createCube(missing=0.2, size=(10, 20, 25))
-    mOrig = createCube(missing=0.2, size=(10, 15))
+    mOrig = createCube(missing=0.05, size=(10, 15))
     facT = perform_CMTF(tOrig, mOrig, r=4)
 
     fullR2X = calcR2X(facT, tOrig, mOrig)
@@ -79,6 +79,7 @@ def test_sort():
 
     tFac = random_cp(tOrig.shape, 3)
     tFac.mFactor = np.random.randn(mOrig.shape[1], 3)
+    tFac.mWeights = np.ones(3)
 
     R2X = calcR2X(tFac, tOrig, mOrig)
     tRec = tl.cp_to_tensor(tFac)


### PR DESCRIPTION
We don't have a test dataset on CMTF (maybe we should), so it would be helpful to have a second view of whether this is done correctly.