### PR TITLE
upgrade python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Cyrillus Tan <cyztan@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.11"
+python = ">=3.9,<3.12"
 numpy = "^1.21"
 tensorly = "^0.8"
 matplotlib = "^3.5.0"


### PR DESCRIPTION
thecell cycle GNE project works with tensorpack, the upgrade was failing because this repo needs also the update.